### PR TITLE
Fix clang warnings

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -15,6 +15,7 @@
 #include <sys/time.h>		/* FreeBSD wants this for the next one.. */
 #include <sys/resource.h>
 #include <poll.h>
+#include <time.h>
 
 #if !defined(WCOREDUMP)
 # define WCOREDUMP(x) 0
@@ -511,21 +512,23 @@ struct child *children;
 	  spawn_mode = SPAWN_PAUSE;
 	  break;
       case '1':
-	  if (spawn_mode != SPAWN_ONE)
+	  if (spawn_mode != SPAWN_ONE) {
               if (failure_mode == SPAWN_PAUSE)
                   uprint("Will spawn one command... (And pause on error)");
               else
                   uprint("Will spawn one command... (And quit on error)");
+    }
 	  if (spawn_mode != SPAWN_NONE)
 	      spawn_mode = SPAWN_ONE;
 	  break;
       case '\n':
       case '-':
-	  if (spawn_mode != SPAWN_CHECK)
+	  if (spawn_mode != SPAWN_CHECK) {
               if (failure_mode == SPAWN_PAUSE)
                   uprint("Resuming... (Will pause on error)");
               else
                   uprint("Resuming... (Will quit on error)");
+    }
 	  spawn_mode = SPAWN_CHECK;
 	  break;
       case '+':

--- a/src/target.c
+++ b/src/target.c
@@ -8,6 +8,7 @@
 #include "os.h"
 
 #include <ctype.h>
+#include <time.h>
 
 #include "target.h"
 #include "term.h"

--- a/src/term.c
+++ b/src/term.c
@@ -269,7 +269,7 @@ int interactive;
             sigaction(SIGABRT, &sa, NULL);
             sigaction(SIGTERM, &sa, NULL);
                     
-            dprint("Input tty initialized (0x%X -> 0x%X)",
+            dprint("Input tty initialized (0x%lX -> 0x%lX)",
                    origt.c_lflag, shmuxt.c_lflag);
           }
         else
@@ -321,6 +321,7 @@ int
 term_togglemsg(void)
 {
     internalmsgs = 1 - internalmsgs;
+    return internalmsgs;
 }
 
 /*
@@ -331,6 +332,7 @@ int
 term_toggledbg(void)
 {
     debugmsgs = 1 - debugmsgs;
+    return debugmsgs;
 }
 
 /*


### PR DESCRIPTION
Fixes the following:
```
gcc -g -O2   -c -o loop.o loop.c
loop.c:517:15: warning: add explicit braces to avoid dangling else [-Wdangling-else]
              else
              ^
loop.c:527:15: warning: add explicit braces to avoid dangling else [-Wdangling-else]
              else
              ^
2 warnings generated.
gcc -g -O2   -c -o target.o target.c
target.c:516:26: warning: implicit declaration of function 'time' is invalid in C99 [-Wimplicit-function-declaration]
    targets[tcur].when = time(NULL);
                         ^
1 warning generated.
gcc -g -O2   -c -o term.o term.c
term.c:273:20: warning: format specifies type 'unsigned int' but the argument has type 'tcflag_t' (aka 'unsigned long') [-Wformat]
                   origt.c_lflag, shmuxt.c_lflag);
                   ^~~~~~~~~~~~~
term.c:273:35: warning: format specifies type 'unsigned int' but the argument has type 'tcflag_t' (aka 'unsigned long') [-Wformat]
                   origt.c_lflag, shmuxt.c_lflag);
                                  ^~~~~~~~~~~~~~
term.c:324:1: warning: control reaches end of non-void function [-Wreturn-type]
}
^
term.c:334:1: warning: control reaches end of non-void function [-Wreturn-type]
}
^
4 warnings generated.
```