### PR TITLE
Add option for staggering spawning of children

### DIFF
--- a/shmux.1
+++ b/shmux.1
@@ -35,6 +35,8 @@ shmux - Shell Multiplexor
 .B -P \fItimeout\fP
 ] [
 .B -T \fItimeout\fP
+] [
+.B -z \fItimeout\fP
 ]
 .B -c \fIcommand\fP
 [ - | \fItargets...\fP ]
@@ -190,6 +192,12 @@ used), output for failed tests will be displayed to help the user
 understand what went wrong.
 .IP "\fB-T \fItimeout\fP"
 Defines the test timeout in seconds.  (Implies \fB-t\fP.)
+.IP "\fB-z \fItimeout\fP"
+Random stagger when spawning children. In order to avoid a thundering
+herd problem when establishing connections to remote machines
+(e.g. shared jump hosts which perform connection startup throttling),
+sleep a random time up to \fItimeout\fP milliseconds before executing
+the command to connect to each target.
 .IP "\fB-m\fP"
 By default the output is displayed as soon as it is received.  For
 multi-line outputs, this will typically result in output from several

--- a/src/exec.c
+++ b/src/exec.c
@@ -13,9 +13,11 @@
 # define _PATH_DEVNULL "/dev/null"
 #endif
 #include <fcntl.h>
+#include <stdlib.h>
 #include <sys/time.h>		/* FreeBSD wants this for the next one.. */
 #include <sys/resource.h>
 #include <signal.h>
+#include <time.h>
 
 #include "exec.h"
 #include "term.h"
@@ -23,12 +25,12 @@
 static char const rcsid[] = "@(#)$Id$";
 
 pid_t
-exec(fd0, fd1, fd2, target, argv, timeout)
-int *fd0, *fd1, *fd2;
+exec(fd0, fd1, fd2, target, argv, timeout, stagger)
+int *fd0, *fd1, *fd2, stagger;
 u_int timeout;
 char *target, **argv;
 {
-    int in[2], out[2], err[2];
+    int in[2], out[2], err[2], millis;
     struct rlimit fdlimit;
     pid_t child;
 
@@ -95,6 +97,8 @@ char *target, **argv;
 	fdlimit.rlim_cur = 1024;
       }
 
+    if (stagger > 0) millis = abs(rand()) % stagger;
+
     /* fork() */
     child = fork();
 
@@ -119,6 +123,7 @@ char *target, **argv;
     else
       {
 	struct sigaction sa;
+	struct timespec spec;
 	int fd;
 	char error[1024];
 
@@ -137,6 +142,12 @@ char *target, **argv;
 	sigaction(SIGTSTP, &sa, NULL);
 	sigaction(SIGCONT, &sa, NULL);
 	sigaction(SIGWINCH, &sa, NULL);
+
+	if (stagger > 0)
+	  {
+	    spec.tv_sec = (time_t) millis / 1000;
+	    spec.tv_nsec = (((long) millis) % 1000) * 1000 * 1000;
+	  }
 
         /* Start a new process group to allow mass-signaling by the parent */
         if (setpgid(0, 0) < 0)
@@ -195,6 +206,7 @@ char *target, **argv;
 	if (dup(err[1]) == -1) abort();
 	if (close(out[1]) == -1) abort();
 	if (fd2 != NULL && close(err[1]) == -1) abort();
+	if (stagger > 0 && nanosleep(&spec, NULL) == -1) abort();
 
 	alarm(timeout);
 

--- a/src/exec.h
+++ b/src/exec.h
@@ -10,6 +10,6 @@
 #if !defined(_EXEC_H_)
 # define _EXEC_H_
 
-pid_t exec(int *, int *, int *, char *, char **, u_int);
+pid_t exec(int *, int *, int *, char *, char **, u_int, int);
 
 #endif

--- a/src/loop.c
+++ b/src/loop.c
@@ -792,9 +792,9 @@ int result;
 **	targets with a simple echo command, and finally running a command.
 */
 int
-loop(cmd, ctimeout, max, spawn, fail, outmode, odir, utest, ping, test)
+loop(cmd, ctimeout, max, spawn, fail, outmode, odir, utest, ping, test, stagger)
 char *cmd, *spawn, *ping, *odir;
-int max, fail, outmode, test;
+int max, fail, outmode, test, stagger;
 u_int ctimeout, utest;
 {
     struct child *children;
@@ -865,7 +865,7 @@ u_int ctimeout, utest;
 	pfd[2].fd = -1;
 	cargv[0] = "fping"; cargv[1] = "-t"; cargv[2] = ping; cargv[3] = NULL;
 	children[0].pid = exec(&(pfd[0].fd), &(pfd[1].fd), &(pfd[2].fd),
-			       NULL, cargv, 0);
+			       NULL, cargv, 0, 0);
 	if (children[0].pid == -1)
 	    /* Error message was given by exec() */
 	    spawn_mode = SPAWN_FATAL;
@@ -1159,7 +1159,7 @@ u_int ctimeout, utest;
 		    children[idx].pid = exec(NULL, &(pfd[idx*3+1].fd),
 					     &(pfd[idx*3+2].fd),
 					     target_getname(), cargv,
-					     analyzer_timeout());
+					     analyzer_timeout(), 0);
 		    if (children[idx].pid == -1)
 			  {
 			    /* Error message was given by exec() */
@@ -1228,7 +1228,8 @@ u_int ctimeout, utest;
 					     &(pfd[idx*3+2].fd),
 					     target_getname(),
                                              target_getcmd(cmd),
-					     ctimeout);
+					     ctimeout,
+					     stagger);
 		    if (children[idx].pid == -1)
 			  {
 			    /* Error message was given by exec() */
@@ -1277,7 +1278,8 @@ u_int ctimeout, utest;
 					     &(pfd[idx*3+2].fd),
 					     target_getname(),
                                              target_getcmd("echo SHMUX."),
-					     abs(test));
+					     abs(test),
+					     stagger);
 
 		    if (children[idx].pid == -1)
 		      {

--- a/src/loop.h
+++ b/src/loop.h
@@ -17,6 +17,6 @@
 #define OUT_IFERR 0x20	/* Output only displayed on error */
 #define OUT_ERR   0x40	/* Error found in output */
 
-int loop(char *, u_int, int, char *, int, int, char *, u_int, char *, int);
+int loop(char *, u_int, int, char *, int, int, char *, u_int, char *, int, int);
 
 #endif

--- a/src/shmux.c
+++ b/src/shmux.c
@@ -16,6 +16,7 @@
 #else
 # define _PATH_TMP "/tmp"
 #endif
+#include <stdlib.h>
 #include <time.h>
 #include <sys/stat.h>
 #if defined(HAVE_PCRE_H)
@@ -82,6 +83,7 @@ int detailed;
     fprintf(stderr, "  -A <test>     Analyze output to determine success from failure.\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "  -o <dir>      Send the output to files under the specified directory.\n");
+    fprintf(stderr, "  -z <millisec> Randomly stagger spawning of children up to this threshold.\n");
     fprintf(stderr, "  -m            Don't mix target outputs.\n");
     fprintf(stderr, "  -b            Show bare output without target names.\n");
     fprintf(stderr, "  -B            Batch mode.\n");
@@ -98,7 +100,7 @@ main(int argc, char **argv)
 {
     int badopt, rc;
     int opt_prefix, opt_status, opt_interactive, opt_quiet, opt_internal, opt_debug;
-    int opt_ctimeout, opt_outmode, opt_maxworkers, opt_fail, opt_vtest;
+    int opt_ctimeout, opt_outmode, opt_maxworkers, opt_fail, opt_vtest, opt_stagger;
     u_int opt_test, opt_analyzer;
     char *opt_analyze, *opt_outanalysis, *opt_erranalysis;
     char *opt_spawn, *opt_command, *opt_odir, *opt_ping, *opt_rcmd;
@@ -107,6 +109,7 @@ main(int argc, char **argv)
     time_t start;
 
     myname = basename(argv[0]);
+    srand((unsigned) getpid());
 
     opt_prefix = opt_status = opt_interactive = 1;
     opt_quiet = opt_internal = opt_debug = 0;
@@ -115,7 +118,7 @@ main(int argc, char **argv)
         opt_maxworkers = atoi(getenv("SHMUX_MAX"));
     else
         opt_maxworkers = DEFAULT_MAXWORKERS;
-    opt_ctimeout = opt_fail = opt_test = opt_vtest = 0;
+    opt_ctimeout = opt_fail = opt_test = opt_vtest = opt_stagger = 0;
     opt_analyze = opt_outanalysis = opt_erranalysis = NULL;
     opt_command = opt_odir = opt_ping = NULL;
     opt_rcmd = getenv("SHMUX_RCMD");
@@ -138,7 +141,7 @@ main(int argc, char **argv)
       {
         int c;
 	
-        c = getopt(argc, argv, "a:A:bBc:C:De:E:FhmM:o:pP:qQr:sS:tT:vV");
+        c = getopt(argc, argv, "a:A:bBc:C:De:E:FhmM:o:pP:qQr:sS:tT:vVz:");
 	
         /* Detect the end of the options. */
         if (c == -1)
@@ -242,6 +245,9 @@ main(int argc, char **argv)
 		     myname, SHMUX_VERSION, pcre_version());
 #endif
 	      exit(RC_OK);
+	  case 'z':
+	      opt_stagger = atoi(optarg);
+	      break;
 	  case '?':
 	      badopt += 1;
 	      break;
@@ -271,6 +277,12 @@ main(int argc, char **argv)
     if (opt_analyzer != ANALYZE_NONE && opt_odir == NULL)
       {
 	fprintf(stderr, "%s: -o option required when using -a/-A!\n", myname);
+	exit(RC_ERROR);
+      }
+
+    if (opt_stagger < 0)
+      {
+	fprintf(stderr, "%s: Invalid -z argument!\n", myname);
 	exit(RC_ERROR);
       }
 
@@ -347,7 +359,7 @@ main(int argc, char **argv)
     /* Loop through targets/commands */
     start = time(NULL);
     rc = loop(opt_command, opt_ctimeout, opt_maxworkers, opt_spawn, opt_fail,
-	      opt_outmode, opt_odir, opt_analyzer, opt_ping, opt_test);
+	      opt_outmode, opt_odir, opt_analyzer, opt_ping, opt_test, opt_stagger);
 
     /* Summary of results unless asked to be quiet */
     if (opt_quiet == 0)


### PR DESCRIPTION
I occasionally run into problems when attempting to use shmux with a number of remote systems which share one or more jump hosts, as the thundering herd of starting many SSH connections at once triggers the connection startup throttling on the jump host and causes some connections to fail.

This change adds a `-z` option for staggering the spawning of children which connect to remote targets by a random duration up to the option argument, given in milliseconds.