### PR TITLE
Convert function definitions to ANSI syntax

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -10,7 +10,7 @@
 SHELL	=	/bin/sh
 CC	=	@CC@
 CPPFLAGS=	@CPPFLAGS@
-CFLAGS	=	@CFLAGS@ -Wno-old-style-definition
+CFLAGS	=	@CFLAGS@
 LDFLAGS	=	@LDFLAGS@
 LIBS	=	@LIBS@
 

--- a/src/analyzer.c
+++ b/src/analyzer.c
@@ -55,10 +55,7 @@ static void loadfile(int, char *, struct condition **list);
 **	Given an open file descriptor, mmap() the corresponding (regular) file
 */
 static void *
-mapfile(errto, fd, name, len)
-int errto, fd;
-char *name;
-size_t *len;
+mapfile(int errto, int fd, char *name, size_t *len)
 {
     struct stat sb;
     void *mm;
@@ -106,11 +103,7 @@ size_t *len;
 **	munmap() a previously mapped file
 */
 static void
-unmapfile(errto, name, mm, len)
-int errto;
-char *name;
-void *mm;
-size_t len;
+unmapfile(int errto, char *name, void *mm, size_t len)
 {
     if (len == 0)
 	return;
@@ -133,10 +126,7 @@ size_t len;
 **	Regular expression (regex_t) initialization
 */
 void
-compile_re(mline, reptr, str)
-int mline;
-void *reptr;
-char *str;
+compile_re(int mline, void *reptr, char *str)
 {
     regex_t *re;
     int errcode;
@@ -163,10 +153,7 @@ char *str;
 **	Perl Compatible Regular Expression (pcre) initialization
 */
 void
-compile_pcre(mline, pcreptr, str)
-int mline;
-void *pcreptr;
-char *str;
+compile_pcre(int mline, void *pcreptr, char *str)
 {
     pcre **re;
     const char *error;
@@ -189,11 +176,7 @@ char *str;
 **	Regular expression initialization routine
 */
 static void
-restr_init(re, comp, ok, str)
-void *re;
-void (*comp)(int, void *, char *);
-int *ok;
-char *str;
+restr_init(void *re, void (*comp)(int, void *, char *), int *ok, char *str)
 {
     char *fname, *rbuf;
     int fd;
@@ -255,10 +238,7 @@ char *str;
 **	Read a list of one line conditions from a file
 */
 static void
-loadfile(type, file, list)
-int type;
-char *file;
-struct condition **list;
+loadfile(int type, char *file, struct condition **list)
 {
     int fd, lineno, cond, max;
     size_t len;
@@ -382,8 +362,7 @@ struct condition **list;
 **	Initialization for the analyzer, called early on.
 */
 int
-analyzer_init(type, outdef, errdef)
-char *type, *outdef, *errdef;
+analyzer_init(char *type, char *outdef, char *errdef)
 {
     if (type == NULL)
 	return ANALYZE_NONE;
@@ -492,10 +471,7 @@ char *type, *outdef, *errdef;
 **	expressions.
 */
 int
-analyzer_run(type, ofd, oname, efd, ename)
-u_int type;
-int ofd, efd;
-char *oname, *ename;
+analyzer_run(u_int type, int ofd, char *oname, int efd, char *ename)
 {
     size_t olen, elen;
     void *output, *errput;
@@ -648,9 +624,7 @@ char *oname, *ename;
 **	specified regular expressions.
 */
 int
-analyzer_lnrun(type, what, str)
-u_int type, what;
-char *str;
+analyzer_lnrun(u_int type, u_int what, char *str)
 {
     struct condition *list;
     int r;

--- a/src/byteset.c
+++ b/src/byteset.c
@@ -22,9 +22,7 @@ static char sets[2][256];
 **	Initialize set[] from a range definition string
 */
 void
-byteset_init(set, definition)
-int set;
-char *definition;
+byteset_init(int set, char *definition)
 {
     char *str, *tok, *dash;
     int i, j;
@@ -80,8 +78,7 @@ char *definition;
 **	Is a byte included in the set?
 */
 int
-byteset_test(set, byte)
-int set, byte;
+byteset_test(int set, int byte)
 {
     assert( set == 0 || set == 1 );
     assert( byte >= 0 && byte <= 255 );

--- a/src/exec.c
+++ b/src/exec.c
@@ -25,10 +25,7 @@
 static char const rcsid[] = "@(#)$Id$";
 
 pid_t
-exec(fd0, fd1, fd2, target, argv, timeout, stagger)
-int *fd0, *fd1, *fd2, stagger;
-u_int timeout;
-char *target, **argv;
+exec(int *fd0, int *fd1, int *fd2, char *target, char **argv, u_int timeout, int stagger)
 {
     int in[2], out[2], err[2], millis;
     struct rlimit fdlimit;

--- a/src/loop.c
+++ b/src/loop.c
@@ -78,8 +78,7 @@ static void set_cmdstatus(int);
 **	SIGINT handler
 */
 static void
-shmux_sigint(sig)
-int sig;
+shmux_sigint(int sig)
 {
   got_sigint += 1;
 }
@@ -92,8 +91,7 @@ int sig;
 **	achieve when we run out.
 */
 void
-setup_fdlimit(fdfactor, max)
-int fdfactor, max;
+setup_fdlimit(int fdfactor, int max)
 {
     struct rlimit fdlimit;
 
@@ -163,8 +161,7 @@ int fdfactor, max;
 **	Used to initialize a child structure whenever a new child is spawned.
 */
 static void
-init_child(kid)
-struct child *kid;
+init_child(struct child *kid)
 {
     kid->num = target_getnum();
     kid->test = kid->passed = 0;
@@ -187,10 +184,7 @@ struct child *kid;
 **	Parse output from children
 */
 static void
-parse_child(name, isfping, verbose_tests, analyzer, kid, std, buffer)
-char *name, *buffer;
-int isfping, verbose_tests, analyzer, std;
-struct child *kid;
+parse_child(char *name, int isfping, int verbose_tests, int analyzer, struct child *kid, int std, char *buffer)
 {
     char *start, *nl;
 
@@ -425,8 +419,7 @@ struct child *kid;
 **	Parse one line of output from fping
 */
 static void
-parse_fping(line)
-char *line;
+parse_fping(char *line)
 {
     char *space;
 		  
@@ -468,9 +461,7 @@ char *line;
 **	Handle user input
 */
 static void
-parse_user(c, children, max)
-int c, max;
-struct child *children;
+parse_user(int c, struct child *children, int max)
 {
     char *cmd;
 
@@ -674,8 +665,7 @@ struct child *children;
 **	Create an output file.
 */
 int
-output_file(fname, dir, name, extension)
-char **fname, *dir, *name, *extension;
+output_file(char **fname, char *dir, char *name, char *extension)
 {
     int sz, fd;
 
@@ -714,9 +704,7 @@ char **fname, *dir, *name, *extension;
 **	Show an output file.
 */
 void
-output_show(name, fd, fname, type)
-char *name, *fname;
-int fd, type;
+output_show(char *name, int fd, char *fname, int type)
 {
     FILE *f;
     int fd2, cont;
@@ -767,8 +755,7 @@ int fd, type;
 **	Use to define whether a command was successful or not.
 */
 static void
-set_cmdstatus(result)
-int result;
+set_cmdstatus(int result)
 {
     assert( spawn_mode != SPAWN_ONE );
 
@@ -792,10 +779,7 @@ int result;
 **	targets with a simple echo command, and finally running a command.
 */
 int
-loop(cmd, ctimeout, max, spawn, fail, outmode, odir, utest, ping, test, stagger)
-char *cmd, *spawn, *ping, *odir;
-int max, fail, outmode, test, stagger;
-u_int ctimeout, utest;
+loop(char *cmd, u_int ctimeout, int max, char *spawn, int fail, int outmode, char *odir, u_int utest, char *ping, int test, int stagger)
 {
     struct child *children;
     struct pollfd *pfd;

--- a/src/shmux.c
+++ b/src/shmux.c
@@ -55,8 +55,7 @@ char *myname;
 static void usage(int);
 
 static void
-usage(detailed)
-int detailed;
+usage(int detailed)
 {
     fprintf(stderr, "Usage: %s [ options ] -c <command> [ - | <target1> [ <target2> ... ] ]\n", myname);
 /*    fprintf(stderr, "Usage: %s [ options ] -i [ <target1> [ <target2> ... ] ]\n", myname);*/

--- a/src/siglist.c
+++ b/src/siglist.c
@@ -17,8 +17,7 @@
 static char const rcsid[] = "@(#)$Id$";
 
 int
-getsignumbyname(name)
-char *name;
+getsignumbyname(char *name)
 {
     int i;
 

--- a/src/status.c
+++ b/src/status.c
@@ -31,8 +31,7 @@ static time_t spawnedchg, changed[5];
 **	Initialize things..
 */
 void
-status_init(pings, tests, analyzer)
-int pings, tests, analyzer;
+status_init(int pings, int tests, int analyzer)
 {
     spawned = 0;
     inphase[0] = inphase[1] = inphase[2] = inphase[3] = inphase[4] = 0;
@@ -50,8 +49,7 @@ int pings, tests, analyzer;
 **	Update the number of children rowming free.
 */
 void
-status_spawned(count)
-int count;
+status_spawned(int count)
 {
     spawned += count;
     spawnedchg = time(NULL);
@@ -62,8 +60,7 @@ int count;
 **	Update the number of target in a particular phase.
 */
 void
-status_phase(phase, count)
-int phase, count;
+status_phase(int phase, int count)
 {
     assert( phase >= -1 && phase < 5 );
     assert( inphase[0] != -1 );

--- a/src/target.c
+++ b/src/target.c
@@ -52,8 +52,7 @@ static int split_argv(const char *, int, char **);
 **	Configure default method
 */
 void
-target_default(cmd)
-char *cmd;
+target_default(char *cmd)
 {
     if (strncmp("sh", cmd, 3) == 0)
 	type = 0;
@@ -77,8 +76,7 @@ char *cmd;
 **	add a target to the list
 */
 int
-target_add(name)
-char *name;
+target_add(char *name)
 {
     if (tsz == 0)
       {
@@ -152,8 +150,7 @@ target_getmax(void)
 **	Find a target by name, and set the current pointer.
 */
 int
-target_setbyname(name)
-char *name;
+target_setbyname(char *name)
 {
     assert( name != NULL );
 
@@ -170,8 +167,7 @@ char *name;
 **	Find a target by host name, and set the current pointer.
 */
 int
-target_setbyhname(name)
-char *name;
+target_setbyhname(char *name)
 {
     assert( name != NULL );
 
@@ -199,8 +195,7 @@ char *name;
 **	Find a target by number, and set the current pointer.
 */
 int
-target_setbynum(num)
-u_int num;
+target_setbynum(u_int num)
 {
     if (num > tmax)
 	return -1;
@@ -246,10 +241,7 @@ target_getnum(void)
 **      - -1 if args was too small
 */
 static int
-split_argv(opts, maxargs, args)
-const char *opts;
-int maxargs;
-char **args;
+split_argv(const char *opts, int maxargs, char **args)
 {
     static char *buf = NULL;
     char *p, q;
@@ -341,8 +333,7 @@ char **args;
 **	Return the current target command.
 */
 char **
-target_getcmd(cmd)
-char *cmd;
+target_getcmd(char *cmd)
 {
     static char **args = NULL;
     static int argsz = 32;
@@ -485,8 +476,7 @@ char *cmd;
 **	Return 0 if there is such a target, -1 otherwise
 */
 int
-target_next(phase)
-int phase;
+target_next(int phase)
 {
     assert( phase > 0 && phase < 5 );
 
@@ -522,8 +512,7 @@ target_start(void)
 **	Set the result of the current phase for the current target.
 */
 void
-target_result(ok)
-int ok;
+target_result(int ok)
 {
     assert( tcur >= 0 && tcur <= tmax );
     assert( targets[tcur].status >= -1 && targets[tcur].status < 4 );
@@ -552,8 +541,7 @@ int ok;
 **	Specialized target_result() routine to deal with ping/pong oddities.
 */
 int
-target_pong(name)
-char *name;
+target_pong(char *name)
 {
     tcur = -1;
     while (++tcur <= tmax)
@@ -591,8 +579,7 @@ char *name;
 **	Set the result of the command execution for the current target.
 */
 void
-target_cmdstatus(status)
-int status;
+target_cmdstatus(int status)
 {
     assert( tcur >= 0 && tcur <= tmax );
     assert( targets[tcur].phase == 3 || targets[tcur].phase == 4 );
@@ -606,8 +593,7 @@ int status;
 **	Report current status of all targets
 */
 void
-target_status(status)
-int status;
+target_status(int status)
 {
     int i, any, tlen;
     char buf[16];
@@ -688,8 +674,7 @@ int status;
 **	Show failures.
 */
 void
-target_results(seconds)
-int seconds;
+target_results(int seconds)
 {
     int i, first;
     int f, t, u, s, e;

--- a/src/term.c
+++ b/src/term.c
@@ -50,8 +50,7 @@ static void gprint(char *, char, char *, va_list);
 **	signal handler
 */
 static void
-shmux_signal(sig)
-int sig;
+shmux_signal(int sig)
 {
     if (sig == SIGWINCH || sig == SIGCONT)
 	got_sigwin += 1;
@@ -78,8 +77,7 @@ int sig;
 **	Initialize terminal handling system.
 */
 void
-term_init(maxlen, prefix, progress, internal, debug, interactive)
-int maxlen, prefix, progress, internal, debug, interactive;
+term_init(int maxlen, int prefix, int progress, int internal, int debug, int interactive)
 {
     static char termcap[2048], area[1024];
     char *term, *ptr;
@@ -216,8 +214,7 @@ term_size(void)
 **	/dev/tty initialization
 */
 static void
-tty_init(interactive)
-int interactive;
+tty_init(int interactive)
 {
     if (ttyin < 0)
       {
@@ -404,8 +401,7 @@ sprint(char *format, ...)
 **	Same as putchar, for stderr.
 */
 static int
-putchar2(c)
-int c;
+putchar2(int c)
 {
     return fputc(c, stderr);
 }
@@ -415,8 +411,7 @@ int c;
 **	Same as putchar, for tty (either stdout or stderr).
 */
 static int
-putchar3(c)
-int c;
+putchar3(int c)
 {
     return fputc(c, ttyout);
 }

--- a/src/units.c
+++ b/src/units.c
@@ -16,8 +16,7 @@ static char const rcsid[] = "@(#)$Id$";
 extern char *myname;
 
 u_int
-unit_time(timestr)
-char *timestr;
+unit_time(char *timestr)
 { 
     char *unit;
 


### PR DESCRIPTION
This change replaces the long obsolete K&R function definition syntax with ANSI syntax, as the former will be deprecated in upcoming C versions and already triggers warnings in recent compilers. The corresponding compiler flag to suppress these warnings is also removed here.